### PR TITLE
Fix chapter 2 forgotten await

### DIFF
--- a/chapters/ch02.asciidoc
+++ b/chapters/ch02.asciidoc
@@ -464,7 +464,7 @@ If we want to take things a bit further, we can chain onto the response object t
 [source,javascript]
 ----
 const res = await fetch('/api/users/john')
-const data = res.json()
+const data = await res.json()
 console.log(data.name)
 // <- 'John Doe'
 ----


### PR DESCRIPTION
Body.json() return a Promise. WIthout the await there, it would log a pending Promise.

Reference documentation:
https://developer.mozilla.org/en-US/docs/Web/API/Body/json

Demo:
https://jsbin.com/putudohafi/1/edit?js,console